### PR TITLE
Windows slash fix

### DIFF
--- a/better-font-awesome-library.php
+++ b/better-font-awesome-library.php
@@ -371,6 +371,10 @@ class Better_Font_Awesome_Library {
 		$theme_directory = get_stylesheet_directory();
 		$plugin_dir = plugin_dir_url( __FILE__ );
 
+		// Handle Windows based installations and differing slash directions
+		$bfa_directory = str_ireplace('\\', '/', $bfa_directory);
+		$theme_directory = str_ireplace('\\', '/', $theme_directory);
+
 		/**
 		 * Check if we're inside a theme or plugin.
 		 *


### PR DESCRIPTION
When running a local dev environment on Windows (eg: WAMP or XAMPP for
example) the check $is_theme would fail due to differences in directory
slashes. This causes the stylesheets to have an incorrect path.
